### PR TITLE
fix: removed unmatched '}' from .yml files

### DIFF
--- a/eza.tera
+++ b/eza.tera
@@ -25,9 +25,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "{{red.hex}}", is_bold: true}
-  user_write: {foreground: "{{yellow.hex}}"}, is_bold: true}
-  user_execute_file: {foreground: "{{green.hex}}"}, is_bold: true}
-  user_execute_other: {foreground: "{{green.hex}}"}, is_bold: true}
+  user_write: {foreground: "{{yellow.hex}}", is_bold: true}
+  user_execute_file: {foreground: "{{green.hex}}", is_bold: true}
+  user_execute_other: {foreground: "{{green.hex}}", is_bold: true}
   group_read: {foreground: "{{red.hex}}"}
   group_write: {foreground: "{{yellow.hex}}"}
   group_execute: {foreground: "{{green.hex}}"}

--- a/themes/frappe/catppuccin-frappe-blue.yml
+++ b/themes/frappe/catppuccin-frappe-blue.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-flamingo.yml
+++ b/themes/frappe/catppuccin-frappe-flamingo.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-green.yml
+++ b/themes/frappe/catppuccin-frappe-green.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-lavender.yml
+++ b/themes/frappe/catppuccin-frappe-lavender.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-maroon.yml
+++ b/themes/frappe/catppuccin-frappe-maroon.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-mauve.yml
+++ b/themes/frappe/catppuccin-frappe-mauve.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-peach.yml
+++ b/themes/frappe/catppuccin-frappe-peach.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-pink.yml
+++ b/themes/frappe/catppuccin-frappe-pink.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-red.yml
+++ b/themes/frappe/catppuccin-frappe-red.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-rosewater.yml
+++ b/themes/frappe/catppuccin-frappe-rosewater.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-sapphire.yml
+++ b/themes/frappe/catppuccin-frappe-sapphire.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-sky.yml
+++ b/themes/frappe/catppuccin-frappe-sky.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-teal.yml
+++ b/themes/frappe/catppuccin-frappe-teal.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/frappe/catppuccin-frappe-yellow.yml
+++ b/themes/frappe/catppuccin-frappe-yellow.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#e78284", is_bold: true}
-  user_write: {foreground: "#e5c890"}, is_bold: true}
-  user_execute_file: {foreground: "#a6d189"}, is_bold: true}
-  user_execute_other: {foreground: "#a6d189"}, is_bold: true}
+  user_write: {foreground: "#e5c890", is_bold: true}
+  user_execute_file: {foreground: "#a6d189", is_bold: true}
+  user_execute_other: {foreground: "#a6d189", is_bold: true}
   group_read: {foreground: "#e78284"}
   group_write: {foreground: "#e5c890"}
   group_execute: {foreground: "#a6d189"}

--- a/themes/latte/catppuccin-latte-blue.yml
+++ b/themes/latte/catppuccin-latte-blue.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-flamingo.yml
+++ b/themes/latte/catppuccin-latte-flamingo.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-green.yml
+++ b/themes/latte/catppuccin-latte-green.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-lavender.yml
+++ b/themes/latte/catppuccin-latte-lavender.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-maroon.yml
+++ b/themes/latte/catppuccin-latte-maroon.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-mauve.yml
+++ b/themes/latte/catppuccin-latte-mauve.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-peach.yml
+++ b/themes/latte/catppuccin-latte-peach.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-pink.yml
+++ b/themes/latte/catppuccin-latte-pink.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-red.yml
+++ b/themes/latte/catppuccin-latte-red.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-rosewater.yml
+++ b/themes/latte/catppuccin-latte-rosewater.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-sapphire.yml
+++ b/themes/latte/catppuccin-latte-sapphire.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-sky.yml
+++ b/themes/latte/catppuccin-latte-sky.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-teal.yml
+++ b/themes/latte/catppuccin-latte-teal.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/latte/catppuccin-latte-yellow.yml
+++ b/themes/latte/catppuccin-latte-yellow.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#d20f39", is_bold: true}
-  user_write: {foreground: "#df8e1d"}, is_bold: true}
-  user_execute_file: {foreground: "#40a02b"}, is_bold: true}
-  user_execute_other: {foreground: "#40a02b"}, is_bold: true}
+  user_write: {foreground: "#df8e1d", is_bold: true}
+  user_execute_file: {foreground: "#40a02b", is_bold: true}
+  user_execute_other: {foreground: "#40a02b", is_bold: true}
   group_read: {foreground: "#d20f39"}
   group_write: {foreground: "#df8e1d"}
   group_execute: {foreground: "#40a02b"}

--- a/themes/macchiato/catppuccin-macchiato-blue.yml
+++ b/themes/macchiato/catppuccin-macchiato-blue.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-flamingo.yml
+++ b/themes/macchiato/catppuccin-macchiato-flamingo.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-green.yml
+++ b/themes/macchiato/catppuccin-macchiato-green.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-lavender.yml
+++ b/themes/macchiato/catppuccin-macchiato-lavender.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-maroon.yml
+++ b/themes/macchiato/catppuccin-macchiato-maroon.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-mauve.yml
+++ b/themes/macchiato/catppuccin-macchiato-mauve.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-peach.yml
+++ b/themes/macchiato/catppuccin-macchiato-peach.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-pink.yml
+++ b/themes/macchiato/catppuccin-macchiato-pink.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-red.yml
+++ b/themes/macchiato/catppuccin-macchiato-red.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-rosewater.yml
+++ b/themes/macchiato/catppuccin-macchiato-rosewater.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-sapphire.yml
+++ b/themes/macchiato/catppuccin-macchiato-sapphire.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-sky.yml
+++ b/themes/macchiato/catppuccin-macchiato-sky.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-teal.yml
+++ b/themes/macchiato/catppuccin-macchiato-teal.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/macchiato/catppuccin-macchiato-yellow.yml
+++ b/themes/macchiato/catppuccin-macchiato-yellow.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#ed8796", is_bold: true}
-  user_write: {foreground: "#eed49f"}, is_bold: true}
-  user_execute_file: {foreground: "#a6da95"}, is_bold: true}
-  user_execute_other: {foreground: "#a6da95"}, is_bold: true}
+  user_write: {foreground: "#eed49f", is_bold: true}
+  user_execute_file: {foreground: "#a6da95", is_bold: true}
+  user_execute_other: {foreground: "#a6da95", is_bold: true}
   group_read: {foreground: "#ed8796"}
   group_write: {foreground: "#eed49f"}
   group_execute: {foreground: "#a6da95"}

--- a/themes/mocha/catppuccin-mocha-blue.yml
+++ b/themes/mocha/catppuccin-mocha-blue.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-flamingo.yml
+++ b/themes/mocha/catppuccin-mocha-flamingo.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-green.yml
+++ b/themes/mocha/catppuccin-mocha-green.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-lavender.yml
+++ b/themes/mocha/catppuccin-mocha-lavender.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-maroon.yml
+++ b/themes/mocha/catppuccin-mocha-maroon.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-mauve.yml
+++ b/themes/mocha/catppuccin-mocha-mauve.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-peach.yml
+++ b/themes/mocha/catppuccin-mocha-peach.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-pink.yml
+++ b/themes/mocha/catppuccin-mocha-pink.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-red.yml
+++ b/themes/mocha/catppuccin-mocha-red.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-rosewater.yml
+++ b/themes/mocha/catppuccin-mocha-rosewater.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-sapphire.yml
+++ b/themes/mocha/catppuccin-mocha-sapphire.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-sky.yml
+++ b/themes/mocha/catppuccin-mocha-sky.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-teal.yml
+++ b/themes/mocha/catppuccin-mocha-teal.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}

--- a/themes/mocha/catppuccin-mocha-yellow.yml
+++ b/themes/mocha/catppuccin-mocha-yellow.yml
@@ -14,9 +14,9 @@ filekinds:
 
 perms:
   user_read: {foreground: "#f38ba8", is_bold: true}
-  user_write: {foreground: "#f9e2af"}, is_bold: true}
-  user_execute_file: {foreground: "#a6e3a1"}, is_bold: true}
-  user_execute_other: {foreground: "#a6e3a1"}, is_bold: true}
+  user_write: {foreground: "#f9e2af", is_bold: true}
+  user_execute_file: {foreground: "#a6e3a1", is_bold: true}
+  user_execute_other: {foreground: "#a6e3a1", is_bold: true}
   group_read: {foreground: "#f38ba8"}
   group_write: {foreground: "#f9e2af"}
   group_execute: {foreground: "#a6e3a1"}


### PR DESCRIPTION
Removed unmatched "}" from all .yml files in /themes and eza.tera. Resolving issue with EZA failing to apply themes.